### PR TITLE
Allow users to configure whether or not Stepper should be able to submit final form step

### DIFF
--- a/examples/submitStepper/src/components/CustomerStepper.tsx
+++ b/examples/submitStepper/src/components/CustomerStepper.tsx
@@ -51,7 +51,7 @@ export default function CustomStepper({
               className="step"
               style={{
                 borderRadius: '50%',
-                border: '1px solid white',
+                border: '1px solid black',
                 width: '20px',
                 height: '20px',
                 backgroundColor: circleColor,

--- a/examples/submitStepper/src/form/SubmitStepperExampleForm.tsx
+++ b/examples/submitStepper/src/form/SubmitStepperExampleForm.tsx
@@ -61,7 +61,7 @@ export default function SubmitStepperExampleForm() {
   }
 
   return (
-    <MultiStepForm>
+    <MultiStepForm stepperSubmitFinal={false}>
       <MultiStepForm.Stepper render={(stepperProps) => CustomStepper(stepperProps)} />
       <MultiStepForm.Step
         name="Step 1"

--- a/examples/submitStepper/src/form/SubmitStepperExampleForm.tsx
+++ b/examples/submitStepper/src/form/SubmitStepperExampleForm.tsx
@@ -85,6 +85,7 @@ export default function SubmitStepperExampleForm() {
         )}
       />
       <MultiStepForm.Step
+        name="Step 3"
         renderStepForm={({ reportStepValidity, handleStepSubmit }) => (
           <StepThree
             data={store}

--- a/src/components/MultiStepForm.tsx
+++ b/src/components/MultiStepForm.tsx
@@ -22,6 +22,8 @@ export type MultiStepFormProps<ParentFormData extends FieldValues> = {
   children:
     | ReactElement<MultiStepFormStepProps<Partial<ParentFormData>>>
     | ReactElement<MultiStepFormStepProps<Partial<ParentFormData>>>[]
+  /** Should Stepper be allowed to submit final step (clicking backwards). */
+  stepperSubmitFinal?: boolean
 }
 
 function MultiStepForm<ParentFormData extends FieldValues>({
@@ -36,6 +38,7 @@ function MultiStepForm<ParentFormData extends FieldValues>({
 
 function MultiStepFormContent<ParentFormData extends FieldValues>({
   children,
+  stepperSubmitFinal = true,
 }: MultiStepFormProps<ParentFormData>) {
   const arrayStepChildren = Children.toArray(children)
   const formSteps: FormStep[] = Children.map(arrayStepChildren, (child) =>
@@ -61,7 +64,10 @@ function MultiStepFormContent<ParentFormData extends FieldValues>({
   const onChangeStep = useCallback(
     (newStepIndex: number) => {
       if (isFormValid) {
-        submitButtonRefs[0]?.meta?.stepperSubmit(newStepIndex)
+        // Unless stepperSubmitFinal == true, then if final step and going backward - don't submit form step
+        if (stepperSubmitFinal || newStepIndex > activeStepIndex || activeStepIndex === numSteps) {
+          submitButtonRefs[0]?.meta?.stepperSubmit(newStepIndex)
+        }
         // this is necessary (even though the above will navigate) to ensure form steps w/o submit buttons are navigated
         setActiveStepIndex(newStepIndex)
       }

--- a/src/components/MultiStepForm.tsx
+++ b/src/components/MultiStepForm.tsx
@@ -28,10 +28,13 @@ export type MultiStepFormProps<ParentFormData extends FieldValues> = {
 
 function MultiStepForm<ParentFormData extends FieldValues>({
   children,
+  stepperSubmitFinal = true,
 }: MultiStepFormProps<ParentFormData>) {
   return (
     <RefProvider>
-      <MultiStepFormContent>{children}</MultiStepFormContent>
+      <MultiStepFormContent stepperSubmitFinal={stepperSubmitFinal}>
+        {children}
+      </MultiStepFormContent>
     </RefProvider>
   )
 }
@@ -65,7 +68,11 @@ function MultiStepFormContent<ParentFormData extends FieldValues>({
     (newStepIndex: number) => {
       if (isFormValid) {
         // Unless stepperSubmitFinal == true, then if final step and going backward - don't submit form step
-        if (stepperSubmitFinal || newStepIndex > activeStepIndex || activeStepIndex === numSteps) {
+        // Submit button will submit and move forward always (onChangeStep is not called)
+        const shouldSubmitFromStepper =
+          stepperSubmitFinal || newStepIndex > activeStepIndex || newStepIndex !== numSteps - 1
+        if (shouldSubmitFromStepper) {
+          console.log('hit branch - would submit from stepper')
           submitButtonRefs[0]?.meta?.stepperSubmit(newStepIndex)
         }
         // this is necessary (even though the above will navigate) to ensure form steps w/o submit buttons are navigated


### PR DESCRIPTION
PR fixes, or allows users to opt into a fix, for the Stepper component submitting the form step when stepping backwards. This is typically a problem in the final step of the form, where the final step may involve writing the multi-step form's state out of the form.

## Change to API

`MultiStepForm`: new **optional** prop `stepperSubmitFinal` which defaults to `true` to preserve backwards compatibility.