### PR TITLE
[BUG-FIX] Use activeStepIndex for non submit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-hook-form-multistep",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-hook-form-multistep",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
         "react-context-refs": "^0.2.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-form-multistep",
   "description": "Extensible multistep forms for React Hook Form.",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": false,
   "author": {
     "name": "Camin McCluskey",

--- a/src/components/MultiStepForm.tsx
+++ b/src/components/MultiStepForm.tsx
@@ -70,7 +70,7 @@ function MultiStepFormContent<ParentFormData extends FieldValues>({
         // Unless stepperSubmitFinal == true, then if final step and going backward - don't submit form step
         // Submit button will submit and move forward always (onChangeStep is not called)
         const shouldSubmitFromStepper =
-          stepperSubmitFinal || newStepIndex > activeStepIndex || newStepIndex !== numSteps - 1
+          stepperSubmitFinal || newStepIndex > activeStepIndex || activeStepIndex !== numSteps - 1
         if (shouldSubmitFromStepper) {
           console.log('hit branch - would submit from stepper')
           submitButtonRefs[0]?.meta?.stepperSubmit(newStepIndex)


### PR DESCRIPTION
PR fixes bug where last step still submitted. We should be using `activeStepIndex` to determine whether or not the current form step is the last one and whether we are stepping backwards from it.